### PR TITLE
Fixed depoy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ from the mail service to set as configuration on the charm.
 
 After you've successfully bootstrapped a Juju environment, run the following:
 
-    juju deploy cs:/~natefinch/discourse --config=cfg.yml --constraints mem=2g
+    juju deploy cs:~natefinch/discourse --config=cfg.yml --constraints mem=2G
     juju expose discourse
 
 Discourse recommends 2GB of RAM for a standard installation.  You can use less,


### PR DESCRIPTION
Slash at the beginning causing:
error: invalid charm name "cs:/~natefinch/discourse"

Lowercase 'g' a the end causes:
error: invalid value "mem=2g" for flag --constraints: bad "mem" constraint: must be a non-negative float with optional M/G/T/P suffix